### PR TITLE
Add pbcs to allowed_values in Manifest carrier method.

### DIFF
--- a/pbshipping/models/carrier.py
+++ b/pbshipping/models/carrier.py
@@ -35,8 +35,9 @@ class Carrier(object):
     PBI = "PBI"
     FEDEX = "FEDEX"
     USP = "USP"
+    PBCS = "PBCS"
 
-    allowable_values = [USPS, PBPRESORT, NEWGISTICS, PBI, FEDEX, USP]  # noqa: E501
+    allowable_values = [USPS, PBPRESORT, NEWGISTICS, PBI, FEDEX, USP, PBCS]  # noqa: E501
 
     """
     Attributes:

--- a/pbshipping/models/manifest.py
+++ b/pbshipping/models/manifest.py
@@ -111,7 +111,7 @@ class Manifest(object):
         """
         if self.local_vars_configuration.client_side_validation and carrier is None:  # noqa: E501
             raise ValueError("Invalid value for `carrier`, must not be `None`")  # noqa: E501
-        allowed_values = ["USPS", "NEWGISTICS", "PBPresort"]  # noqa: E501
+        allowed_values = ["USPS", "NEWGISTICS", "PBPresort", "pbcs"]  # noqa: E501
         if self.local_vars_configuration.client_side_validation and carrier not in allowed_values:  # noqa: E501
             raise ValueError(
                 "Invalid value for `carrier` ({0}), must be one of {1}"  # noqa: E501


### PR DESCRIPTION
According to the doc, NEWGISTIICS is deprecated or not used for new api calls, added pbcs as a new value to creating manifest