### PR TITLE
feat: add local_vars_configuration that is set in ApiClient to model …

### DIFF
--- a/pbshipping/api_client.py
+++ b/pbshipping/api_client.py
@@ -657,6 +657,9 @@ class ApiClient(object):
                 if klass.attribute_map[attr] in data:
                     value = data[klass.attribute_map[attr]]
                     kwargs[attr] = self.__deserialize(value, attr_type)
+        
+        if self.configuration is not None:
+            kwargs['local_vars_configuration'] = self.configuration
 
         instance = klass(**kwargs)
 

--- a/pbshipping/models/tracking_response.py
+++ b/pbshipping/models/tracking_response.py
@@ -49,7 +49,7 @@ class TrackingResponse(object):
         'delivery_location': 'str',
         'delivery_location_description': 'str',
         'signed_by': 'str',
-        'weight': 'int',
+        'weight': 'float',
         'weight_oum': 'str',
         'reattempt_date': 'date',
         'reattempt_time': 'str',

--- a/pbshipping/models/tracking_response.py
+++ b/pbshipping/models/tracking_response.py
@@ -36,16 +36,21 @@ class TrackingResponse(object):
     openapi_types = {
         'package_count': 'int',
         'carrier': 'str',
+        'service_name': 'str',
         'tracking_number': 'str',
         'reference_number': 'str',
         'status': 'str',
         'updated_date': 'date',
         'updated_time': 'str',
         'ship_date': 'date',
+        'ship_time': 'str',
+        'ship_time_offset': 'str',
         'estimated_delivery_date': 'date',
         'estimated_delivery_time': 'str',
+        'estimated_delivery_time_offset': 'str',
         'delivery_date': 'date',
         'delivery_time': 'str',
+        'delivery_time_offset': 'str',
         'delivery_location': 'str',
         'delivery_location_description': 'str',
         'signed_by': 'str',
@@ -55,22 +60,29 @@ class TrackingResponse(object):
         'reattempt_time': 'str',
         'destination_address': 'TrackingAddress',
         'sender_address': 'TrackingAddress',
-        'scan_details_list': 'list[TrackingResponseScanDetailsList]'
+        'scan_details_list': 'list[TrackingResponseScanDetailsList]',
+        'current_status': 'TrackingResponseScanDetailsList',
+        'last_package_status_location': 'str'
     }
 
     attribute_map = {
         'package_count': 'packageCount',
         'carrier': 'carrier',
+        'service_name': 'serviceName',
         'tracking_number': 'trackingNumber',
         'reference_number': 'referenceNumber',
         'status': 'status',
         'updated_date': 'updatedDate',
         'updated_time': 'updatedTime',
         'ship_date': 'shipDate',
+        'ship_time': 'shipTime',
+        'ship_time_offset': 'shipTimeOffset',
         'estimated_delivery_date': 'estimatedDeliveryDate',
         'estimated_delivery_time': 'estimatedDeliveryTime',
+        'estimated_delivery_time_offset': 'estimatedDeliveryTimeOffset',
         'delivery_date': 'deliveryDate',
         'delivery_time': 'deliveryTime',
+        'delivery_time_offset': 'deliveryTimeOffset',
         'delivery_location': 'deliveryLocation',
         'delivery_location_description': 'deliveryLocationDescription',
         'signed_by': 'signedBy',
@@ -80,10 +92,44 @@ class TrackingResponse(object):
         'reattempt_time': 'reattemptTime',
         'destination_address': 'destinationAddress',
         'sender_address': 'senderAddress',
-        'scan_details_list': 'scanDetailsList'
+        'scan_details_list': 'scanDetailsList',
+        'current_status': 'currentStatus',
+        'last_package_status_location': 'lastPackageStatusLocation'
     }
 
-    def __init__(self, package_count=None, carrier=None, tracking_number=None, reference_number=None, status=None, updated_date=None, updated_time=None, ship_date=None, estimated_delivery_date=None, estimated_delivery_time=None, delivery_date=None, delivery_time=None, delivery_location=None, delivery_location_description=None, signed_by=None, weight=None, weight_oum=None, reattempt_date=None, reattempt_time=None, destination_address=None, sender_address=None, scan_details_list=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(self, 
+            package_count=None, 
+            carrier=None, 
+            service_name=None,
+            tracking_number=None, 
+            reference_number=None, 
+            status=None, 
+            updated_date=None, 
+            updated_time=None, 
+            ship_date=None, 
+            ship_time=None,
+            ship_time_offset=None,
+            estimated_delivery_date=None, 
+            estimated_delivery_time=None, 
+            estimated_delivery_time_offset=None, 
+            delivery_date=None, 
+            delivery_time=None, 
+            delivery_time_offset=None, 
+            delivery_location=None,
+            delivery_location_description=None,
+            signed_by=None,
+            weight=None,
+            weight_oum=None,
+            reattempt_date=None, 
+            reattempt_time=None, 
+            destination_address=None, 
+            sender_address=None, 
+            scan_details_list=None, 
+            current_status=None,
+            last_package_status_location=None,
+            local_vars_configuration=None
+        ):  # noqa: E501
+        import pdb; pdb.set_trace()
         """TrackingResponse - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -112,6 +158,13 @@ class TrackingResponse(object):
         self._sender_address = None
         self._scan_details_list = None
         self.discriminator = None
+        self._ship_time=None,
+        self._ship_time_offset=None,
+        self._estimated_delivery_time_offset=None, 
+        self._delivery_time_offset=None, 
+        self._current_status=None,
+        self._last_package_status_location=None,
+
 
         if package_count is not None:
             self.package_count = package_count
@@ -157,6 +210,19 @@ class TrackingResponse(object):
             self.sender_address = sender_address
         if scan_details_list is not None:
             self.scan_details_list = scan_details_list
+
+        if ship_time is not None:
+            self._ship_time=ship_time
+        if ship_time_offset is not None:
+            self._ship_time_offset=ship_time_offset,
+        if estimated_delivery_time_offset is not None:
+            self._estimated_delivery_time_offset=estimated_delivery_time_offset, 
+        if delivery_time_offset is not None:
+            self._delivery_time_offset=delivery_time_offset
+        if current_status is not None:
+            self._current_status=current_status
+        if last_package_status_location is not None:
+            self._last_package_status_location=last_package_status_location
 
     @property
     def package_count(self):
@@ -631,6 +697,114 @@ class TrackingResponse(object):
         """
 
         self._scan_details_list = scan_details_list
+
+    @property
+    def ship_time(self):
+        """Gets the ship_time of this TrackingResponse.
+
+        :return: The ship_time of this TrackingResponse.
+        :rtype: datetime
+        """
+        return self._ship_time
+
+    @ship_time.setter
+    def ship_time(self, ship_time):
+        """Sets the ship_time of this TrackingResponse.
+
+        :param ship_time: The ship_time of this TrackingResponse.
+        :type: datetime
+        """
+        self._ship_time = ship_time
+
+    @property
+    def ship_time_offset(self):
+        """Gets the ship_time_offset of this TrackingResponse.
+
+        :return: The ship_time_offset of this TrackingResponse.
+        :rtype: int
+        """
+        return self._ship_time_offset
+
+    @ship_time_offset.setter
+    def ship_time_offset(self, ship_time_offset):
+        """Sets the ship_time_offset of this TrackingResponse.
+
+        :param ship_time_offset: The ship_time_offset of this TrackingResponse.
+        :type: int
+        """
+        self._ship_time_offset = ship_time_offset
+
+    @property
+    def estimated_delivery_time_offset(self):
+        """Gets the estimated_delivery_time_offset of this TrackingResponse.
+
+        :return: The estimated_delivery_time_offset of this TrackingResponse.
+        :rtype: int
+        """
+        return self._estimated_delivery_time_offset
+
+    @estimated_delivery_time_offset.setter
+    def estimated_delivery_time_offset(self, estimated_delivery_time_offset):
+        """Sets the estimated_delivery_time_offset of this TrackingResponse.
+
+        :param estimated_delivery_time_offset: The estimated_delivery_time_offset of this TrackingResponse.
+        :type: int
+        """
+        self._estimated_delivery_time_offset = estimated_delivery_time_offset
+
+    @property
+    def delivery_time_offset(self):
+        """Gets the delivery_time_offset of this TrackingResponse.
+
+        :return: The delivery_time_offset of this TrackingResponse.
+        :rtype: int
+        """
+        return self._delivery_time_offset
+
+    @delivery_time_offset.setter
+    def delivery_time_offset(self, delivery_time_offset):
+        """Sets the delivery_time_offset of this TrackingResponse.
+
+        :param delivery_time_offset: The delivery_time_offset of this TrackingResponse.
+        :type: int
+        """
+        self._delivery_time_offset = delivery_time_offset
+
+    @property
+    def current_status(self):
+        """Gets the current_status of this TrackingResponse.
+
+        :return: The current_status of this TrackingResponse.
+        :rtype: str
+        """
+        return self._current_status
+
+    @current_status.setter
+    def current_status(self, current_status):
+        """Sets the current_status of this TrackingResponse.
+
+        :param current_status: The current_status of this TrackingResponse.
+        :type: str
+        """
+        self._current_status = current_status
+
+    @property
+    def last_package_status_location(self):
+        """Gets the last_package_status_location of this TrackingResponse.
+
+        :return: The last_package_status_location of this TrackingResponse.
+        :rtype: str
+        """
+        return self._last_package_status_location
+
+    @last_package_status_location.setter
+    def last_package_status_location(self, last_package_status_location):
+        """Sets the last_package_status_location of this TrackingResponse.
+
+        :param last_package_status_location: The last_package_status_location of this TrackingResponse.
+        :type: str
+        """
+        self._last_package_status_location = last_package_status_location
 
     def to_dict(self):
         """Returns the model properties as a dict"""

--- a/pbshipping/models/tracking_response.py
+++ b/pbshipping/models/tracking_response.py
@@ -157,12 +157,13 @@ class TrackingResponse(object):
         self._sender_address = None
         self._scan_details_list = None
         self.discriminator = None
-        self._ship_time=None,
-        self._ship_time_offset=None,
-        self._estimated_delivery_time_offset=None, 
-        self._delivery_time_offset=None, 
-        self._current_status=None,
-        self._last_package_status_location=None,
+        self._service_name=None
+        self._ship_time=None
+        self._ship_time_offset=None
+        self._estimated_delivery_time_offset=None
+        self._delivery_time_offset=None
+        self._current_status=None
+        self._last_package_status_location=None
 
 
         if package_count is not None:
@@ -210,6 +211,8 @@ class TrackingResponse(object):
         if scan_details_list is not None:
             self.scan_details_list = scan_details_list
 
+        if service_name is not None:
+            self._service_name = service_name
         if ship_time is not None:
             self._ship_time=ship_time
         if ship_time_offset is not None:
@@ -264,6 +267,27 @@ class TrackingResponse(object):
         """
 
         self._carrier = carrier
+
+    @property
+    def service_name(self):
+        """Gets the service_name of this TrackingResponse.  # noqa: E501
+
+
+        :return: The service_name of this TrackingResponse.  # noqa: E501
+        :rtype: str
+        """
+        return self._service_name
+
+    @service_name.setter
+    def service_name(self, service_name):
+        """Sets the service_name of this TrackingResponse.
+
+
+        :param service_name: The service_name of this TrackingResponse.  # noqa: E501
+        :type: str
+        """
+
+        self._service_name = service_name
 
     @property
     def tracking_number(self):

--- a/pbshipping/models/tracking_response.py
+++ b/pbshipping/models/tracking_response.py
@@ -129,7 +129,6 @@ class TrackingResponse(object):
             last_package_status_location=None,
             local_vars_configuration=None
         ):  # noqa: E501
-        import pdb; pdb.set_trace()
         """TrackingResponse - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()

--- a/pbshipping/models/tracking_response_scan_details_list.py
+++ b/pbshipping/models/tracking_response_scan_details_list.py
@@ -73,7 +73,27 @@ class TrackingResponseScanDetailsList(object):
         'standardized_event_description': 'standardizedEventDescription'
     }
 
-    def __init__(self, event_date=None, event_time=None, event_city=None, event_state_or_province=None, postal_code=None, country=None, scan_type=None, scan_description=None, package_status=None, local_vars_configuration=None):  # noqa: E501
+    def __init__(
+            self, 
+            event_date=None, 
+            event_time=None, 
+            event_time_offset=None, 
+            event_city=None, 
+            event_state_or_province=None, 
+            event_leg=None,
+            event_type=None,
+            postal_code=None, 
+            country=None, 
+            scan_type=None, 
+            scan_description=None, 
+            package_status=None, 
+            l1_code=None,
+            l1_description=None,
+            l2_description=None,
+            standardized_event_code=None,
+            standardized_event_description=None,
+            local_vars_configuration=None
+        ):  # noqa: E501
         """TrackingResponseScanDetailsList - a model defined in OpenAPI"""  # noqa: E501
         if local_vars_configuration is None:
             local_vars_configuration = Configuration()
@@ -81,23 +101,37 @@ class TrackingResponseScanDetailsList(object):
 
         self._event_date = None
         self._event_time = None
+        self._event_time_offset = None
         self._event_city = None
         self._event_state_or_province = None
+        self._event_leg = None
+        self._event_type = None
         self._postal_code = None
         self._country = None
         self._scan_type = None
         self._scan_description = None
         self._package_status = None
+        self._l1_code = None
+        self._l1_description = None
+        self._l2_description = None
+        self._standardized_event_code = None
+        self._standardized_event_description = None
         self.discriminator = None
 
         if event_date is not None:
             self.event_date = event_date
         if event_time is not None:
             self.event_time = event_time
+        if event_time_offset is not None:
+            self.event_time_offset = event_time_offset
         if event_city is not None:
             self.event_city = event_city
         if event_state_or_province is not None:
             self.event_state_or_province = event_state_or_province
+        if event_leg is not None:
+            self.event_leg = event_leg
+        if event_type is not None:
+            self.event_type = event_type
         if postal_code is not None:
             self.postal_code = postal_code
         if country is not None:
@@ -108,6 +142,16 @@ class TrackingResponseScanDetailsList(object):
             self.scan_description = scan_description
         if package_status is not None:
             self.package_status = package_status
+        if l1_code is not None:
+            self.l1_code = l1_code
+        if l1_description is not None:
+            self.l1_description = l1_description
+        if l2_description is not None:
+            self.l2_description = l2_description
+        if standardized_event_code is not None:
+            self.standardized_event_code = standardized_event_code
+        if standardized_event_description is not None:
+            self.standardized_event_description = standardized_event_description
 
     @property
     def event_date(self):
@@ -152,6 +196,27 @@ class TrackingResponseScanDetailsList(object):
         self._event_time = event_time
 
     @property
+    def event_time_offset(self):
+        """Gets the event_time_offset of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The event_time_offset of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._event_time_offset
+
+    @event_time_offset.setter
+    def event_time_offset(self, event_time_offset):
+        """Sets the event_time_offset of this TrackingResponseScanDetailsList.
+
+
+        :param event_time: The event_time_offset of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._event_time_offset = event_time_offset
+
+    @property
     def event_city(self):
         """Gets the event_city of this TrackingResponseScanDetailsList.  # noqa: E501
 
@@ -192,6 +257,48 @@ class TrackingResponseScanDetailsList(object):
         """
 
         self._event_state_or_province = event_state_or_province
+
+    @property
+    def event_leg(self):
+        """Gets the event_leg of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The event_leg of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._event_leg
+
+    @event_leg.setter
+    def event_leg(self, event_leg):
+        """Sets the event_leg of this TrackingResponseScanDetailsList.
+
+
+        :param event_leg: The event_leg of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._event_leg = event_leg
+
+    @property
+    def event_type(self):
+        """Gets the event_type of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The event_type of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._event_type
+
+    @event_type.setter
+    def event_type(self, event_type):
+        """Sets the event_type of this TrackingResponseScanDetailsList.
+
+
+        :param event_type: The event_type of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._event_type = event_type
 
     @property
     def postal_code(self):
@@ -298,6 +405,110 @@ class TrackingResponseScanDetailsList(object):
 
         self._package_status = package_status
 
+    @property
+    def l1_code(self):
+        """Gets the l1_code of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The l1_code of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._l1_code
+
+    @l1_code.setter
+    def l1_code(self, l1_code):
+        """Sets the l1_code of this TrackingResponseScanDetailsList.
+
+
+        :param l1_code: The l1_code of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._l1_code = l1_code
+
+    @property
+    def l1_description(self):
+        """Gets the l1_description of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The l1_description of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._l1_description
+
+    @l1_description.setter
+    def l1_description(self, l1_description):
+        """Sets the l1_description of this TrackingResponseScanDetailsList.
+
+
+        :param l1_description: The l1_description of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._l1_description = l1_description
+
+    @property
+    def l2_description(self):
+        """Gets the l2_description of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The l2_description of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._l2_description
+
+    @l2_description.setter
+    def l2_description(self, l2_description):
+        """Sets the l2_description of this TrackingResponseScanDetailsList.
+
+
+        :param l2_description: The l2_description of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._l2_description = l2_description
+
+    @property
+    def standardized_event_code(self):
+        """Gets the standardized_event_code of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The standardized_event_code of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._standardized_event_code
+
+    @standardized_event_code.setter
+    def standardized_event_code(self, standardized_event_code):
+        """Sets the standardized_event_code of this TrackingResponseScanDetailsList.
+
+
+        :param standardized_event_code: The standardized_event_code of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._standardized_event_code = standardized_event_code
+
+    @property
+    def standardized_event_description(self):
+        """Gets the standardized_event_description of this TrackingResponseScanDetailsList.  # noqa: E501
+
+
+        :return: The standardized_event_description of this TrackingResponseScanDetailsList.  # noqa: E501
+        :rtype: str
+        """
+        return self._standardized_event_description
+
+    @standardized_event_description.setter
+    def standardized_event_description(self, standardized_event_description):
+        """Sets the standardized_event_description of this TrackingResponseScanDetailsList.
+
+
+        :param standardized_event_description: The standardized_event_description of this TrackingResponseScanDetailsList.  # noqa: E501
+        :type: str
+        """
+
+        self._standardized_event_description = standardized_event_description
     def to_dict(self):
         """Returns the model properties as a dict"""
         result = {}

--- a/pbshipping/models/tracking_response_scan_details_list.py
+++ b/pbshipping/models/tracking_response_scan_details_list.py
@@ -36,25 +36,41 @@ class TrackingResponseScanDetailsList(object):
     openapi_types = {
         'event_date': 'date',
         'event_time': 'str',
+        'event_time_offset': 'str',
         'event_city': 'str',
         'event_state_or_province': 'str',
-        'postal_code': 'int',
+        'event_leg': 'str',
+        'event_type': 'str',
+        'postal_code': 'str',
         'country': 'str',
         'scan_type': 'str',
         'scan_description': 'str',
-        'package_status': 'str'
+        'package_status': 'str',
+        'l1_code': 'str',
+        'l1_description': 'str',
+        'l2_description': 'str',
+        'standardized_event_code': 'str',
+        'standardized_event_description': 'str'
     }
 
     attribute_map = {
         'event_date': 'eventDate',
         'event_time': 'eventTime',
+        'event_time_offset': 'eventTimeOffset',
         'event_city': 'eventCity',
         'event_state_or_province': 'eventStateOrProvince',
+        'event_leg': 'eventLeg',
+        'event_type': 'eventType',
         'postal_code': 'postalCode',
         'country': 'country',
         'scan_type': 'scanType',
         'scan_description': 'scanDescription',
-        'package_status': 'packageStatus'
+        'package_status': 'packageStatus',
+        'l1_code': 'l1Code',
+        'l1_description': 'l1Description',
+        'l2_description': 'l2Description',
+        'standardized_event_code': 'standardizedEventCode',
+        'standardized_event_description': 'standardizedEventDescription'
     }
 
     def __init__(self, event_date=None, event_time=None, event_city=None, event_state_or_province=None, postal_code=None, country=None, scan_type=None, scan_description=None, package_status=None, local_vars_configuration=None):  # noqa: E501


### PR DESCRIPTION
…deserialization


Hi I am currently using the PB API in the sandbox and currently, calls to `purchase_shipping_label` in sandbox do not work because the returned Address object is

```
"toAddress":{"company":"PITNEY BOWES RETURNS","addressLines":["PARCEL RETURN SERVICE","",""],"cityTown":"","stateProvince":"","postalCode":"56901"},
```

and are missing `countryCode`, this causes the following behaviour
1. Request is returned including the `toAddress` above
2. It is deserialized into `pbshipping.models.address.Address` object
3. the __init__ setter property for Address will raise an Error saying that there is no country_code because `client_side_validation` is True

The change in this PR lets us set the `client_side_validation` during deserialization of a request to whatever it is set to in `ApiClient.__init__`'s configuration object
